### PR TITLE
Update prize specification with the latest information

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ for judging, is available at
         take advantage of this layout to optimize their computations.
 -   Submissions may be written in any programming language.
 -   If competitors create their own test harness, it must be determined by the judges to be running a benchmark equivalent to the provided test harness.
+    - Note that the input to the MSM routine are arkworks representations of `bls377::G1Affine` and `<bls377::Fr as PrimeField>::BigInt` at version `0.3.0`.
+      If you would like to use a different representation, you should contact the judging team to determine if it is permissible.
 -   Submissions must not cause stability issues when run on the target device.
 -   Submissions must not require the device to be rooted (i.e. it must be possible to integrate the solution into an app on the Google Play Store, although competitors do not need to do so for the competition).
 -   Submissions must include documentation, in English, to understand the optimization approach.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ for judging, is available at
 
 June 10 - Competition begins
 
-July 25 - Mid-competition submission due
+August 4 - Mid-competition submission due
 
-September 10 - Final submission due
+October 1 - Final submission due
 
 ### Mid-competition Submission
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ All trials for the final judging will be conducted on a single target device, at
 
 ## Prize Allocation
 
-Prizes will be distributed from the total Prize Reward according to a Rank-Weighted Performance-based scoring system. The baseline score of each competitor's solution will be measured in Mean Latency as described above, and will be used to determine the rank of the competitors, with the lowest Mean Latency resulting in the 1st rank. In order to calculate the prize share, the multicative inverse of the Mean Latency will be used as a weighting score for each qualifying submission (i.e. submissions that pass all constraints, including beating the baseline by at least 10%). Additionally, a Rank-Based multiplier will be applied to each competitor's Inverse Latency to determine their final score and resulting Prize Payout. The final Prize Payout will be determined as the submission Inverse Latency, divided by the sum of the Inverse Latencies for all qualifying submissions, and multiplied by the Rank Multipliers.
-
+Prizes will be distributed from the total Prize Reward according to a Rank-Weighted Performance-based scoring system.
+The baseline score of each competitor's solution will be measured in Mean Latency as described above, and will be used to determine the rank of the competitors, with the lowest Mean Latency resulting in the 1st rank.
+In order to calculate the prize share, the multiplicative inverse of the Mean Latency will be used as a weighting score for each qualifying submission (i.e. submissions that pass all constraints, including beating the baseline by at least 10%).
+Additionally, a Rank-Based multiplier will be applied to each competitor's Inverse Latency to determine their final score and resulting Prize Payout.
+The final Prize Payout will be determined as the submission Inverse Latency, divided by the sum of the Inverse Latencies for all qualifying submissions, and multiplied by the Rank Multipliers.
 
 **Baseline Latency: 3000 ms**
 
@@ -120,19 +123,25 @@ Prizes will be distributed from the total Prize Reward according to a Rank-Weigh
 
 |  | RANK | Latency | Rank Multiplier | Weighted Score | Prize Share | Prize Payout |
 |--|--|--|--|--|--|--|
-| Alice | 1st | 1400 | 4x | 4/1400 | .60 | $225,869 |
-| Bob | 2nd | 2200 | 2x | 2/2200 | .19 | $71,867 |
-| Carrol | 3rd | 2500 | 1.5x | 1.5/2500 | .13 | $47,432 |
-| Dave | 4th | 2650 | 1x | 1/2650 | .08 | $29,832 |
-| Eve | 5th | 2900 | 1x | 0 (did not qualify) | 0 | $0 |
+| Alice | 1st | 1400 | 8x | 4/1400 | .622 | $233,249 |
+| Bob | 2nd | 2200 | 5x | 2/2200 | .247 | $92,769 |
+| Carrol | 3rd | 2500 | 3x | 1/2500 | .131 | $48,982 |
+| Dave | 4th | 2650 | 0x | 1/2650 | .00 | $0 |
+| Eve | 5th | 2900 | 0x | 0 (did not qualify) | 0 | $0 |
 | SUM |  |  |  |  |  | $375,000 |
 
 - Weighted Score =  Inverse Latency *  Rank Multiplier[1]
 - Prize Share  =  Weighted Score / SUM of  all Weighted Scores
 - Prize Payout  =  Prize Share  * Total Prize Reward
 
-Baseline Latency mentioned above is an example, and not the value that will be used. Please note that prize sponsors reserve the right to in good faith reduce or increase a competitors score if doing so falls within the spirit of discouraging “loophole” solutions that are useless to the goals of the prize and in encouraging solutions that are particularly novel or creative. The Rank Multipliers to be used will not be finalized until the number of competitors is finalized, but will be chosen to enable a distribution curve roughly proportional to the example shown given the solutions provided.
+Baseline Latency mentioned above is an example, and not the value that will be used.
+Please note that prize sponsors reserve the right to in good faith reduce or increase a competitors score if doing so falls within the spirit of discouraging “loophole” solutions that are useless to the goals of the prize and in encouraging solutions that are particularly novel or creative.
 
+Finalized Rank Multipliers will be as follows:
+* 8x for 1st place
+* 5x for 2nd place
+* 3x for 3rd place
+* 0x for 4th place and below
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $$Q=\sum^n_{i=1} k_i*P_i$$
 
 ### Hardware & Benchmarks
 
--   All submissions will be tested on the [Samsung Galaxy A13 5G](https://www.devicespecifications.com/en/model/46da57d2) ([SoC MediaTek Dimensity 700 (MT6833)](https://www.mediatek.com/products/smartphones-2/dimensity-700)).
+-   All submissions will be tested on the [Samsung Galaxy A13 5G](https://www.devicespecifications.com/en/model/46da57d2) (Model SM-A136ULGDXAA with [SoC MediaTek Dimensity 700 (MT6833)](https://www.mediatek.com/products/smartphones-2/dimensity-700)).
 -   The baseline will be the Arkworks MSM implementation over BLS12-377 G1. Submissions must beat this baseline by at least 10% in order to be eligible for the prize.
 -   The baseline Android application including a [test harness] is provided, and may be used by competitors as the basis for their submission. Competitors may create their own application and test harness.
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ The final Prize Payout will be determined as the submission Inverse Latency, div
 
 |  | RANK | Latency | Rank Multiplier | Weighted Score | Prize Share | Prize Payout |
 |--|--|--|--|--|--|--|
-| Alice | 1st | 1400 | 8x | 4/1400 | .622 | $233,249 |
-| Bob | 2nd | 2200 | 5x | 2/2200 | .247 | $92,769 |
-| Carrol | 3rd | 2500 | 3x | 1/2500 | .131 | $48,982 |
-| Dave | 4th | 2650 | 0x | 1/2650 | .00 | $0 |
+| Alice | 1st | 1400 | 8x | 8/1400 | .622 | $233,249 |
+| Bob | 2nd | 2200 | 5x | 5/2200 | .247 | $92,769 |
+| Carrol | 3rd | 2500 | 3x | 3/2500 | .131 | $48,982 |
+| Dave | 4th | 2650 | 0x | 0/2650 | 0 | $0 |
 | Eve | 5th | 2900 | 0x | 0 (did not qualify) | 0 | $0 |
 | SUM |  |  |  |  |  | $375,000 |
 
-- Weighted Score =  Inverse Latency *  Rank Multiplier[1]
+- Weighted Score =  Inverse Latency *  Rank Multiplier
 - Prize Share  =  Weighted Score / SUM of  all Weighted Scores
 - Prize Payout  =  Prize Share  * Total Prize Reward
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ for judging, is available at
 -   Submissions may take advantage of any hardware features of the target device (Samsung Galaxy A13 5G).
     - E.g. The SoC in the A13 5G can run 32-bit and 64-bit instruction sets. Submissions may use any
         supported instruction set for their implementation.
+    - E.g. This device also has 8 cores in a 2.6 BIG.little architecture. Optimizations may
+        take advantage of this layout to optimize their computations.
 -   Submissions may be written in any programming language.
 -   If competitors create their own test harness, it must be determined by the judges to be running a benchmark equivalent to the provided test harness.
 -   Submissions must not cause stability issues when run on the target device.


### PR DESCRIPTION
Update to the MSM on Mobile prize specification including:
* Finalization of the prize multipliers, now that the number of competitors is known.
* Update to the submission dates, following up on an announcement by the ZPrize committee.
* Clarify the exact device model that will be used for judging.
* Add a callout for the BIG.little architecture in the phone to encourage competitors to consider it.
* Add a note to make explicit the benchmark input representation.